### PR TITLE
Change simple.ork load location in examples

### DIFF
--- a/examples/lazy.py
+++ b/examples/lazy.py
@@ -11,7 +11,7 @@ with orhelper.OpenRocketInstance() as instance:
     orh = orhelper.Helper(instance)
 
     # Load document, run simulation and get data and events
-    doc = orh.load_doc('simple.ork')
+    doc = orh.load_doc(os.path.join(os.path.dirname(__file__), 'simple.ork'))
     sim = doc.getSimulation(0)
 
 

--- a/examples/lazy.py
+++ b/examples/lazy.py
@@ -11,7 +11,7 @@ with orhelper.OpenRocketInstance() as instance:
     orh = orhelper.Helper(instance)
 
     # Load document, run simulation and get data and events
-    doc = orh.load_doc(os.path.join('examples', 'simple.ork'))
+    doc = orh.load_doc('simple.ork')
     sim = doc.getSimulation(0)
 
 

--- a/examples/monte_carlo.py
+++ b/examples/monte_carlo.py
@@ -17,7 +17,7 @@ class LandingPoints(list):
 
             # Load the document and get simulation
             orh = orhelper.Helper(instance)
-            doc = orh.load_doc(os.path.join('examples', 'simple.ork'))
+            doc = orh.load_doc('simple.ork')
             sim = doc.getSimulation(0)
 
             # Randomize various parameters

--- a/examples/monte_carlo.py
+++ b/examples/monte_carlo.py
@@ -17,7 +17,7 @@ class LandingPoints(list):
 
             # Load the document and get simulation
             orh = orhelper.Helper(instance)
-            doc = orh.load_doc('simple.ork')
+            doc = orh.load_doc(os.path.dirname(__file__), 'simple.ork')
             sim = doc.getSimulation(0)
 
             # Randomize various parameters

--- a/examples/simple_plot.py
+++ b/examples/simple_plot.py
@@ -11,7 +11,7 @@ with orhelper.OpenRocketInstance() as instance:
 
     # Load document, run simulation and get data and events
 
-    doc = orh.load_doc('simple.ork')
+    doc = orh.load_doc(os.path.dirname(__file__), 'simple.ork')
     sim = doc.getSimulation(0)
     orh.run_simulation(sim)
     data = orh.get_timeseries(sim, [FlightDataType.TYPE_TIME, FlightDataType.TYPE_ALTITUDE, FlightDataType.TYPE_VELOCITY_Z])

--- a/examples/simple_plot.py
+++ b/examples/simple_plot.py
@@ -11,7 +11,7 @@ with orhelper.OpenRocketInstance() as instance:
 
     # Load document, run simulation and get data and events
 
-    doc = orh.load_doc(os.path.join('examples', 'simple.ork'))
+    doc = orh.load_doc('simple.ork')
     sim = doc.getSimulation(0)
     orh.run_simulation(sim)
     data = orh.get_timeseries(sim, [FlightDataType.TYPE_TIME, FlightDataType.TYPE_ALTITUDE, FlightDataType.TYPE_VELOCITY_Z])


### PR DESCRIPTION
As a complete noob to orhelper, I had some trouble getting just a basic example script to work, I kept getting a 'FileNotFoundError' for the design file. The problem was that the example files take 'examples/simple.ork' as the default location for the .ork file, but if I run the script, that is already inside the examples-directory, the script looked for simple.ork inside 'examples/examples.ork' which just threw the exception.

So I just removed the extra examples-directory reference so that the example files look for simple.ork inside their relative directory, which is already the examples-directory.

Note: again, I have close to zero experience with orhelper, so I'm sorry if this is a bogus PR.