### PR TITLE
pull rocket from simulation, not simulation options

### DIFF
--- a/examples/monte_carlo.py
+++ b/examples/monte_carlo.py
@@ -22,7 +22,7 @@ class LandingPoints(list):
 
             # Randomize various parameters
             opts = sim.getOptions()
-            rocket = opts.getRocket()
+            rocket = sim.getRocket()
 
             # Run num simulations and add to self
             for p in range(num):


### PR DESCRIPTION
OR version 22.02 has moved the getRocket() method from simulation options to the simulation itself. This updates the Monte Carlo example to this version.