### PR TITLE
Move orhelper logger out of file scope

### DIFF
--- a/orhelper/_orhelper.py
+++ b/orhelper/_orhelper.py
@@ -9,8 +9,6 @@ import numpy as np
 
 from ._enums import *
 
-logger = logging.getLogger(__name__)
-
 CLASSPATH = os.environ.get("CLASSPATH", "OpenRocket-15.03.jar")
 
 __all__ = [
@@ -26,10 +24,14 @@ class OpenRocketInstance:
         JVM will always be shutdown.
     """
 
-    def __init__(self, jar_path: str = CLASSPATH, log_level: Union[OrLogLevel, str] = OrLogLevel.ERROR):
+    def __init__(self, jar_path: str = CLASSPATH, or_log_level: Union[OrLogLevel, str] = OrLogLevel.ERROR):
         """ jar_path is the full path of the OpenRocket .jar file to use
-            log_level can be either OFF, ERROR, WARN, INFO, DEBUG, TRACE and ALL
+            or_log_level is the log level for OpenRocket, and can be either OFF, ERROR, WARN, INFO, DEBUG, TRACE, or ALL
+            or_log_level does not set the log level for orhelper
         """
+
+        self.logger = logging.getLogger(__name__)
+        
         self.openrocket = None
         self.started = False
 
@@ -45,7 +47,7 @@ class OpenRocketInstance:
     def __enter__(self):
         jvm_path = jpype.getDefaultJVMPath()
 
-        logger.info(f"Starting JVM from {jvm_path} CLASSPATH={self.jar_path}")
+        self.logger.info(f"Starting JVM from {jvm_path} CLASSPATH={self.jar_path}")
 
         jpype.startJVM(jvm_path, "-ea", f"-Djava.class.path={self.jar_path}")
 
@@ -88,11 +90,11 @@ class OpenRocketInstance:
             window.dispose()
 
         jpype.shutdownJVM()
-        logger.info("JVM shut down")
+        self.logger.info("JVM shut down")
         self.started = False
 
         if ex is not None:
-            logger.exception("Exception while calling OpenRocket", exc_info=(ex, value, tb))
+            self.logger.exception("Exception while calling OpenRocket", exc_info=(ex, value, tb))
 
     def _translate_log_level(self):
         # ----- Java imports -----


### PR DESCRIPTION
Since the orhelper logger is created in the file scope of `_orhelper.py`, it is created when orhelper is imported. This means that to assign settings to that logger, clients have to import `logging` themselves, get the logger that orhelper will be assigned with `logging.getLogger('orhelper._orhelper')`, assign settings, and then finally import orhelper. This is quite ugly in client code and it would be much nicer if the logger was created after import, i.e. in the `OpenRocketInstance` constructor.