### PR TITLE
Update ORHelper for the new Core and Swing package names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,5 +113,7 @@ dmypy.json
 
 OpenRocket*.jar
 
+orhelper/bin/
+
 venv/
 .idea/

--- a/README.md
+++ b/README.md
@@ -2,25 +2,26 @@
 orhelper is a module which aims to facilitate interacting and scripting with OpenRocket from Python.
 
 ## Prerequisites
-- OpenRocket 15.03
-- Java JDK 1.8
-     - [Open JDK 1.8](https://github.com/ojdkbuild/ojdkbuild)
-     - [Oracle JDK 8](https://www.oracle.com/java/technologies/javase/javase8-archive-downloads.html) (requires signup)
-     - Ubuntu: `sudo apt-get install openjdk-8-jre`
-- Python >=3.6
+- OpenRocket (tested with version 23.09)
+- Java JDK 17. Possible sources include:
+     - [Open JDK 17](https://jdk.java.net/archive/#:~:text=17.0.2%20\(build%2017.0.2%2B8\))
+     - [Oracle JDK 17](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html)
+     - Ubuntu: `sudo apt-get install openjdk-17-jre`
+     - macOS (using [Homebrew](https://brew.sh/)): `brew install openjdk@17`
+- Python >= 3.6
 
 ## Setup JDK
 
 ### Linux
 For most people jpype will be able to automatically find the JDK. However, if it fails or you want to be sure you are using the correct version, add the JDK path to a JAVA_HOME environment variable:
-- Find installation directory (e.g. `/usr/lib/jvm/[YOUR JDK 1.8 FOLDER HERE]`)
+- Locate your JDK installation directory (e.g. `/usr/lib/jvm/[YOUR JDK 17 FOLDER HERE]`)
 - Open the `~/.bashrc` file with your favorite text editor (will likely need sudo privileges)
 - Add the following line to the `~/.bashrc` file:
-    ```
-    export JAVA_HOME="/usr/lib/jvm/[YOUR JDK 1.8 FOLDER HERE]"
+    ```bash
+    export JAVA_HOME="/usr/lib/jvm/[YOUR JDK 17 FOLDER HERE]"
     ```
 - Restart your terminal or run the following for the changes to take effect:
-    ```
+    ```bash
     source ~/.bashrc
     ```
 
@@ -28,30 +29,47 @@ For most people jpype will be able to automatically find the JDK. However, if it
 
 - Set Windows environment variables to the following:
     - Oracle
-        ```
-        JAVA_HOME = C:\Program Files\Java\[YOUR JDK 1.8 FOLDER HERE]
+        ```bash
+        JAVA_HOME = C:\Program Files\Java\[YOUR JDK 17 FOLDER HERE]
         ```
     - OpenJDK
+        ```bash
+        JAVA_HOME = C:\Program Files\OpenJDK\[YOUR JDK 17 FOLDER HERE]
         ```
-        JAVA_HOME = C:\Program Files\ojdkbuild\[YOUR JDK 1.8 FOLDER HERE]
-        ```
+
+### macOS
+
+On macOS, JPype should be able to find the JDK automatically in most cases. If it doesn't, or if you want to ensure you're using a specific JDK version (JDK 17 in this case), you can set the JAVA_HOME environment variable manually to the path of your JDK installation:
+
+1. Open the Terminal application.
+2. Locate your JDK 17 installation directory. This is usually `/Library/Java/JavaVirtualMachines/[YOUR JDK 17 FOLDER HERE]/Contents/Home`. You can verify the path by running `/usr/libexec/java_home -v 17` in Terminal, which should output the correct path to JDK 17 if it's installed.
+3. Set the JAVA_HOME environment variable by adding the following line to your shell profile file (`~/.bash_profile` for Bash or `~/.zshrc` for Zsh, depending on your shell):
+
+    ```bash
+    export JAVA_HOME='/Library/Java/JavaVirtualMachines/[YOUR JDK 17 FOLDER HERE]/Contents/Home'
+    ```
+4. Apply the changes by running `source ~/.bash_profile` or `source ~/.zshrc`, depending on which file you edited.
+5. Verify the JAVA_HOME variable is set correctly by running `echo $JAVA_HOME` in Terminal. It should display the path to JDK 17.
+
+This ensures that orhelper and other Java-dependent applications use the correct version of Java (JDK 17) on your macOS system.
 
 ## Installing
 
 - Install orhelper from pip
-    ```
+    ```bash
     pip install orhelper
     ```
 
-- [Download](https://github.com/openrocket/openrocket/releases/download/release-15.03/OpenRocket-15.03.jar) the OpenRocket .jar file (if you don't already have it)
+- [Download](https://openrocket.info/downloads.html?vers=latest#content-JAR) the OpenRocket.jar file (if you don't already have it)
     - Linux  
-        ```
-        wget https://github.com/openrocket/openrocket/releases/download/release-15.03/OpenRocket-15.03.jar
+        Change `<RELEASE>` to the OpenRocket version number you'd like to download, e.g. `23.09`
+        ```bash
+        wget https://github.com/openrocket/openrocket/releases/download/release-<RELEASE>/OpenRocket-<RELEASE>.jar
         ```
 
-- Set environment variable `CLASSPATH` path to OpenRocket .jar file. (Only required if it's not already at `.\OpenRocket-15.03.jar`)
+- Set environment variable `CLASSPATH` path to OpenRocket.jar file. (Only required if it's not already at `.\OpenRocket.jar`)
     ```
-    CLASSPATH=\some\path\to\OpenRocket-15.03.jar
+    CLASSPATH=\some\path\to\OpenRocket.jar
     ```
 
 - See `examples/` for usage examples

--- a/examples/lazy.py
+++ b/examples/lazy.py
@@ -11,7 +11,7 @@ with orhelper.OpenRocketInstance() as instance:
     orh = orhelper.Helper(instance)
 
     # Load document, run simulation and get data and events
-    doc = orh.load_doc(os.path.join('examples', 'simple.ork'))
+    doc = orh.load_doc(os.path.join(os.path.dirname(__file__), 'simple.ork'))
     sim = doc.getSimulation(0)
 
 

--- a/examples/monte_carlo.py
+++ b/examples/monte_carlo.py
@@ -22,7 +22,7 @@ class LandingPoints(list):
 
             # Randomize various parameters
             opts = sim.getOptions()
-            rocket = opts.getRocket()
+            rocket = sim.getRocket()
 
             # Run num simulations and add to self
             for p in range(num):

--- a/examples/monte_carlo.py
+++ b/examples/monte_carlo.py
@@ -17,7 +17,7 @@ class LandingPoints(list):
 
             # Load the document and get simulation
             orh = orhelper.Helper(instance)
-            doc = orh.load_doc(os.path.join('examples', 'simple.ork'))
+            doc = orh.load_doc(os.path.join(os.path.dirname(__file__), 'simple.ork'))
             sim = doc.getSimulation(0)
 
             # Randomize various parameters

--- a/examples/simple_plot.py
+++ b/examples/simple_plot.py
@@ -11,7 +11,7 @@ with orhelper.OpenRocketInstance() as instance:
 
     # Load document, run simulation and get data and events
 
-    doc = orh.load_doc(os.path.join('examples', 'simple.ork'))
+    doc = orh.load_doc(os.path.join(os.path.dirname(__file__), 'simple.ork'))
     sim = doc.getSimulation(0)
     orh.run_simulation(sim)
     data = orh.get_timeseries(sim, [FlightDataType.TYPE_TIME, FlightDataType.TYPE_ALTITUDE, FlightDataType.TYPE_VELOCITY_Z])

--- a/orhelper/_enums.py
+++ b/orhelper/_enums.py
@@ -15,7 +15,7 @@ class OrLogLevel(Enum):
     TRACE = auto()
     ALL = auto()
 
-# Mirrors net.sf.openrocket.simulation.FlightDataType
+# Mirrors info.openrocket.core.simulation.FlightDataType
 class FlightDataType(Enum):
     TYPE_TIME = auto()
     TYPE_ALTITUDE = auto()
@@ -73,7 +73,7 @@ class FlightDataType(Enum):
     TYPE_TIME_STEP = auto()
     TYPE_COMPUTATION_TIME = auto()
 
-# Mirrors net.sf.openrocket.simulation.FlightEvent
+# Mirrors info.openrocket.core.simulation.FlightEvent
 class FlightEvent(Enum):
     LAUNCH = auto()
     IGNITION = auto()

--- a/orhelper/_orhelper.py
+++ b/orhelper/_orhelper.py
@@ -11,7 +11,7 @@ from ._enums import *
 
 logger = logging.getLogger(__name__)
 
-CLASSPATH = os.environ.get("CLASSPATH", "OpenRocket-15.03.jar")
+CLASSPATH = os.environ.get("CLASSPATH", "OpenRocket.jar")
 
 __all__ = [
     'OpenRocketInstance',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="orhelper",
-    version="0.1.3",
+    version="0.1.4",
     author="Andrei Popescu",
     author_email="Popescu.Andrei.David@gmail.com",
     description="OrHelper is a module which aims to facilitate interacting and scripting with OpenRocket from Python.",


### PR DESCRIPTION
This PR updates the references from the old `net.sf.openrocket` package to `info.openrocket.core` and `info.openrocket.swing`. So the plugin now works with the latest unstable version of OR.